### PR TITLE
return timeout/interval IDs and name the functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,11 @@
-~function() {
+~function(window) {
     const oldSetTimeout = window.setTimeout
-    window.setTimeout = function(fn, timeout) {
-        oldSetTimeout.call(window, () => requestAnimationFrame(fn), timeout)
+    window.setTimeout = function setTimeout(fn, timeout) {
+        return oldSetTimeout.call(window, () => requestAnimationFrame(fn), timeout)
     }
 
     const oldSetInterval = window.setInterval
-    window.setInterval = function(fn, interval) {
-        oldSetInterval.call(window, () => requestAnimationFrame(fn), interval)
+    window.setInterval = function setInterval(fn, interval) {
+        return oldSetInterval.call(window, () => requestAnimationFrame(fn), interval)
     }
-}()
+}(window)


### PR DESCRIPTION
The former is necessary in order for `clearTimeout` and `clearInterval` to work, and the function names are used in the call stack; I also made `window` a parameter of the IIFE and passed it in, although it could be a micro-optimization in this case.
